### PR TITLE
freeloader to use `map` instead of `replace` for performance

### DIFF
--- a/segysak/segy/_segy_loader.py
+++ b/segysak/segy/_segy_loader.py
@@ -963,7 +963,7 @@ def segy_freeloader(
         d_map = {dval: i for i, dval in enumerate(as_unique)}
         index_name = f"{dim}_index"
         dim_index_names.append(index_name)
-        head_df.loc[:, index_name] = head_df[trace_field].replace(d_map)
+        head_df.loc[:, index_name] = head_df[trace_field].map(d_map)
 
     if (
         head_df[dim_index_names].shape


### PR DESCRIPTION
I am working through using `segy_freeloader` and things were going slow.
I broke down the function and noticed the `replace` function was taking time.
[This StackOverflow answer](https://stackoverflow.com/a/41987136/12127259) points out that `map` may be faster.

I ran a [timing test](https://gist.github.com/fr1ll/7673abe5b3f1b640bc6c0e0fe2feaf8c) for series of a range of sizes.
In my test, `map` is 100x faster for larger series.
![2020-10-05_timing-test-map-vs-replace](https://user-images.githubusercontent.com/29168593/95152631-24710a00-0753-11eb-9150-974f38f84db5.png)

Please let me know if my style is problematic for this PR, I am new at this.
I read the style guide and noticed that normally we should submit an issue prior to a PR,
but since this was a smallish change, thought I'd just submit the PR.

