### PR TITLE
Check for invalid byte offsets before loading/scanning

### DIFF
--- a/segysak/segy/_segy_loader.py
+++ b/segysak/segy/_segy_loader.py
@@ -814,9 +814,6 @@ def _loader_converter_header_handling(
         )
 
     head_bin = segy_bin_scrape(segyfile, **segyio_kwargs)
-    head_loc = AttrDict(
-        dict(cdp=cdp, offset=offset, iline=iline, xline=xline, cdpx=cdpx, cdpy=cdpy)
-    )
 
     if all(map(lambda x: x is None, (cdp, iline, xline, offset))):
         # lets try and guess the data types if no hints given

--- a/tests/fixtures_segy.py
+++ b/tests/fixtures_segy.py
@@ -44,6 +44,10 @@ TEST_FILES_SEGYIO_3DG = [
     ("small-ps.sgy", {"iline": 189, "xline": 193, "offset": 37}),
 ]
 
+TEST_FILES_SEGYIO_3D_BAD_OFFSET = [
+    ("acute-small.sgy", {"iline": 189, "xline": 194}),
+]
+
 TEST_FILES_SEGYIO_2D = [
     None,
 ]
@@ -173,6 +177,19 @@ def segyio3d_test_files(request):
     ids=[file for file, _ in TEST_FILES_SEGYIO_3DG],
 )
 def segyio3dps_test_files(request):
+    file, segyio_kwargs = request.param
+    return (file, segyio_kwargs)
+
+
+@pytest.fixture(
+    scope="session",
+    params=[
+        (TEST_DATA_SEGYIO / file, segyio_kwargs)
+        for file, segyio_kwargs in TEST_FILES_SEGYIO_3D_BAD_OFFSET
+    ],
+    ids=[file for file, _ in TEST_FILES_SEGYIO_3D_BAD_OFFSET]
+)
+def segyio3d_bad_offsets_files(request):
     file, segyio_kwargs = request.param
     return (file, segyio_kwargs)
 

--- a/tests/test_seismic_segy.py
+++ b/tests/test_seismic_segy.py
@@ -187,6 +187,12 @@ def test_segyiotests_2ds_wheaderscrap(segyio3d_test_files):
     assert isinstance(ds, xr.Dataset)
 
 
+def test_segyio_bad_offsets(temp_dir, segyio3d_bad_offsets_files):
+    file, segyio_kwargs = segyio3d_bad_offsets_files
+    with pytest.raises(ValueError):
+        segy_loader(str(file), **segyio_kwargs)
+
+
 def test_segyiotests_ps_2ncdf(temp_dir, segyio3dps_test_files):
     file, segyio_kwargs = segyio3dps_test_files
     seisnc = temp_dir / file.with_suffix(".siesnc").name


### PR DESCRIPTION
Closes #64 

This PR adds a sanity checking function `_validate_offset_val` that checks the key byte offset values passed to `segysak.segy._segy_loader:_loader_converter_header_handling` for invalid `segyio Enum` values and raises a `ValueError` if found.